### PR TITLE
Enable persistence of sql database in container

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -34,9 +34,9 @@ RUN adduser \
     --uid "${UID}" \
     appuser
 
-RUN mkdir /config /app
+RUN mkdir /config /app /data
 COPY ./Docker/config.toml /config/config.toml
-RUN chown ${UID}:${UID} /config/config.toml /app
+RUN chown ${UID}:${UID} /config/config.toml /app /data
 
 ENV TZ=Etc/UTC \
     APP_USER=appuser \
@@ -50,5 +50,7 @@ COPY --from=builder /${APP_NAME}/target/release/${APP_NAME} .
 RUN chown -R $APP_USER:$APP_USER /app
 
 USER appuser
+
+VOLUME [ "/data" ]
 
 CMD ["/app/fercord"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG APP_NAME
-ARG UID=10001
+ARG UID=1001
 RUN adduser \
     --disabled-password \
     --gecos "" \
@@ -36,10 +36,9 @@ RUN adduser \
 
 RUN mkdir /config /app /data
 COPY ./Docker/config.toml /config/config.toml
-RUN chown ${UID}:${UID} /config/config.toml /app /data
+RUN chown -R ${UID}:${UID} /config /app /data
 
 ENV TZ=Etc/UTC \
-    APP_USER=appuser \
     CONFIG=/config/config.toml \
     RUST_BACKTRACE=0 \
     RUST_LOG="info,sqlx::query=warn"

--- a/Docker/config.toml
+++ b/Docker/config.toml
@@ -1,2 +1,2 @@
 job_interval_min = 1
-database_url = "sqlite:///data/fercord.db"
+database_url = "sqlite:///data/fercord.db?mode=rwc"

--- a/Docker/config.toml
+++ b/Docker/config.toml
@@ -1,1 +1,2 @@
 job_interval_min = 1
+database_url = "sqlite:///data/fercord.db"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 A discord bot written in Rust, for personal use.
 
 ## Configuration
+### When running locally/directly
+
+You can specify the location of the config file by setting the `CONFIG` environment variable (i.e.: `CONFIG=$XDG_CONFIG_HOME/fercord/config.toml`) or if not specified we look in `.config/config.toml` in the current working directory. 
+
+Example `config.toml`:
 
 ```toml
 discord_token = "your-bot-token"
-database_url = "postgres://fercord:fercord@localhost/fercord"
+database_url = "sqlite://fercord.db"
 redis_url = "redis://localhost/"
 job_interval_min = 1
 shard_key = "c69b7bb6-0ca4-40da-8bad-26d9d4d2fb50"
@@ -37,6 +42,8 @@ This means the following environment variables HAVE to be specified in order for
 * FERCORD_SHARD_KEY
 
 If you want a different job interval, you can specify it through `FERCORD_JOB_INTERVAL_MIN`.
+
+The sqlite database is placed in the `/data` directory and called `fercord.db`. The container exposes `/data` as a volume, so it will persist between updates etc.
 
 ### RUST_LOG
 


### PR DESCRIPTION
- Add /data folder and config for sqlite database in Dockerfile
- add /data from docker to exported volumes
- Fix UID in Dockerfile