### PR TITLE
fix: Set fetch-depth to 0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
             fetch-tags: true
-            fetch-depth: 1
+            fetch-depth: 0
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx


### PR DESCRIPTION
Set fetch depth for the docker pipeline back to 0. Setting it to 1 causes tag detection to fail