### PR TITLE
feat: Add roll command

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -124,7 +124,7 @@ jobs:
           wait-for-processing: true
 
   cargo-test:
-    needs: [rust-clippy-analyze, is-changelog-updated]
+    needs: [is-changelog-updated]
     if: ${{ needs.is-changelog-updated.outputs.needs-check == 'true' }}
     name: Run unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,7 +14,9 @@ on:
     branches: [ "main" ]
     types: [ready_for_review, opened, synchronize]
 
-concurrency: "PR${{ github.event.pull_request && github.event.number }}"
+concurrency:
+  group: "pr-${{ github.event.pull_request.id }}"
+  cancel-in-progress: true
 
 jobs:
   is-changelog-updated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,11 +1093,10 @@ dependencies = [
  "fercord_storage",
  "interim",
  "poise",
- "reqwest 0.12.9",
+ "rstest",
  "serde",
  "serde_json",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1287,6 +1286,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2439,6 +2444,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2695,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2807,36 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.90",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "fercord_storage",
  "interim",
  "poise",
+ "rand",
  "rstest",
  "serde",
  "serde_json",
@@ -3551,9 +3552,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -3572,9 +3573,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "2"
 clap = { version = "4", features = ["derive", "env"] }
 reqwest = { version = "0.12", features = ["stream", "rustls-tls"]}
 tokio-stream = "0.1"
+rstest = "0.23"
 
 fercord_common = { path = "./fercord_common", version = "0.1"}
 fercord_storage = { path = "./fercord_storage", version = "0.3"}
@@ -45,7 +46,6 @@ features = ["rt-multi-thread", "time"]
 [workspace.dependencies.anyhow]
 version = "1"
 features = ["backtrace"]
-
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [profile.release]

--- a/fercord_bot/CHANGELOG.md
+++ b/fercord_bot/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ## [Unreleased] - ReleaseDate
 
-### Added
 - feat: `/reminder` not also accepts `[day|tomorrow] at [hour][am|pm]` inputs.
 - feat: `/roll` command to roll dice (up to 255d255)
 - feat: `@bot register` prefix-command to register slash commands
+- chore: dependency updates
 
 ## [0.3.5] - 2024-12-02
 - chore: Update dependencies

--- a/fercord_bot/CHANGELOG.md
+++ b/fercord_bot/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 - feat: `/reminder` not also accepts `[day|tomorrow] at [hour][am|pm]` inputs.
+- feat: `/roll` command to roll dice (up to 255d255)
+- feat: `@bot register` prefix-command to register slash commands
 
 ## [0.3.5] - 2024-12-02
 - chore: Update dependencies

--- a/fercord_bot/CHANGELOG.md
+++ b/fercord_bot/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+- feat: `/reminder` not also accepts `[day|tomorrow] at [hour][am|pm]` inputs.
+
 ## [0.3.5] - 2024-12-02
 - chore: Update dependencies
 

--- a/fercord_bot/Cargo.toml
+++ b/fercord_bot/Cargo.toml
@@ -25,10 +25,10 @@ tracing-subscriber = {version = "0.3", features = ["default", "env-filter"]}
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 interim = { workspace = true }
-reqwest = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 
-[dependencies.tokio-stream]
-version = "0.1"
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/fercord_bot/Cargo.toml
+++ b/fercord_bot/Cargo.toml
@@ -21,13 +21,14 @@ poise = { workspace = true}
 serde = { workspace = true}
 serde_json = { workspace = true}
 tracing = { workspace = true }
-tracing-subscriber = {version = "0.3", features = ["default", "env-filter"]}
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
 interim = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
+tracing-subscriber = {version = "0.3", features = ["default", "env-filter"]}
+rand = "0.8"
 
 
 [dev-dependencies]

--- a/fercord_bot/src/discord/commands.rs
+++ b/fercord_bot/src/discord/commands.rs
@@ -14,6 +14,7 @@ use fercord_storage::prelude::{
 use crate::discord::Context;
 
 const FROM_NOW: &str = "from now";
+const AT: &str = "at";
 
 /// Set the timezone for this server (used by time related commands).
 #[poise::command(slash_command)]
@@ -217,7 +218,7 @@ where
     span.record("cleaned_input", field::debug(&cleaned_input));
     event!(Level::TRACE, ?cleaned_input, "Cleaned up raw input");
 
-    if let Ok(parsed_datetime) = parse_date_string(&cleaned_input, now.fixed_offset(), Dialect::Us)
+    if let Ok(parsed_datetime) = parse_date_string(&cleaned_input, now.fixed_offset(), Dialect::Uk)
     {
         event!(
             Level::TRACE,
@@ -248,6 +249,12 @@ pub(crate) fn clean_input(natural_input: String) -> String {
         let from_now_len = FROM_NOW.len();
 
         pre_clean.drain(now_pos..now_pos + from_now_len);
+    }
+
+    if let Some(at_pos) = pre_clean.find(AT) {
+        let at_len = AT.len();
+
+        pre_clean.drain(at_pos..at_pos + at_len);
     }
 
     pre_clean.trim().to_string()

--- a/fercord_bot/src/discord/commands.rs
+++ b/fercord_bot/src/discord/commands.rs
@@ -1,20 +1,31 @@
-use anyhow::{anyhow, Result};
+use std::num::NonZeroU8;
+
+use anyhow::{anyhow, Result, Context as AnyhowContext};
 use chrono::{DateTime, Utc};
 use chrono_tz::{Tz, TZ_VARIANTS};
 use interim::{parse_date_string, Dialect};
 use poise::serenity_prelude as serenity;
 use tracing::{debug, event, field, trace_span, warn, Level};
+use rand::prelude::*;
 
-use fercord_storage::prelude::{
-    db::Repository,
-    model::{guild_timezone::GuildTimezone, reminder::Reminder},
-    *,
-};
-
+use fercord_storage::prelude::{*, guild_timezone::GuildTimezone};
 use crate::discord::Context;
 
 const FROM_NOW: &str = "from now";
 const AT: &str = "at";
+
+/// Register slash commands
+#[poise::command(prefix_command)]
+pub async fn register(ctx: Context<'_>) -> Result<()> {
+    let span = trace_span!(
+        "fercord.discord.register",
+    );
+    let _enter = span.enter();
+
+    poise::builtins::register_application_commands_buttons(ctx).await.context("Error registering slash commands")?;
+
+    Ok(())
+}
 
 /// Set the timezone for this server (used by time related commands).
 #[poise::command(slash_command)]
@@ -73,6 +84,41 @@ pub async fn timezone(
 
         Err(anyhow!("Could not determine the guild id"))
     }
+}
+
+/// Roll dice
+/// 
+/// * count: The amount of dice to roll
+/// * sides: the sides on the dice
+#[poise::command(slash_command)]
+pub async fn roll(ctx: Context<'_>,
+    #[description = "How many dice do you want to roll?"] #[min = 1] #[max = 255] count: NonZeroU8,
+    #[description = "How many sides does the dice have?"] #[min = 2] #[max = 255] sides: NonZeroU8,
+) -> Result<()> {
+    let span = trace_span!(
+        "fercord.discord.roll",
+        guild_id = field::Empty,
+        die_command = "{count}d{sides}"
+    );
+    let _enter = span.enter();
+    event!(Level::TRACE, "Received roll command for {count}d{sides}");
+    let guild_id = ctx.guild_id().context("Error retrieving guild id")?;
+    span.record("guild_id", field::debug(&guild_id));
+
+    ctx.defer_ephemeral().await?;
+
+    let mut rng = rand::thread_rng();
+    
+    let mut rolls: Vec<usize> = Vec::with_capacity(count.get() as usize);
+    rolls.resize(count.get().into(), Default::default());
+    rolls.fill_with(move || rng.gen_range(1..=(sides.get() as usize)));
+
+    let roll_total = rolls.into_iter().sum::<usize>();
+    event!(Level::TRACE, "Rolled {count}d{sides} for a total value of {roll_total}");
+    
+    ctx.say(format!("You rolled {count}d{sides} for a total value of {roll_total}")).await?;
+    
+    Ok(())
 }
 
 /// Create a reminder

--- a/fercord_bot/src/discord/tests.rs
+++ b/fercord_bot/src/discord/tests.rs
@@ -1,11 +1,38 @@
-use chrono::Utc;
+use chrono::{Duration, NaiveTime, TimeDelta, Timelike, Utc};
+use rstest::*;
 
 use crate::discord::commands::*;
 
 /// `"5 minutes"`
 const EXPECTED: &str = "5 minutes";
 
-#[test]
+fn duration_for_dhm_from_now(days: i64, h: u32, m: u32, s: u32) -> TimeDelta {
+    let now = Utc::now();
+    let time = NaiveTime::from_hms_opt(h, m, s).expect("Expected valid NaiveTime");
+    let days_from_now = (now + Duration::days(days)).date_naive();
+
+    days_from_now.and_time(time) - now.naive_utc().with_nanosecond(0).unwrap()
+}
+
+#[rstest]
+#[case("in 5 minutes", TimeDelta::minutes(5))]
+#[case("tomorrow at 8am", duration_for_dhm_from_now(1.into(), 8, 0, 0))]
+#[case("in 1 hour", TimeDelta::hours(1))]
+fn check_parser(#[case] input: &str, #[case] expected: TimeDelta) {
+    // Arrange
+    let now = Utc::now().with_nanosecond(0).unwrap();
+
+    // Act
+    let parsed = parse_human_time(input, Utc, Some(now));
+
+    // Assert
+    assert!(parsed.is_ok(), "Could not parse '{input}' to a DateTime");
+    let unwrapped = parsed.unwrap();
+    assert!(unwrapped > now, "Parsed time appears to be in the past: unwrapped={unwrapped} now={now}");
+    assert_eq!(expected, (unwrapped - now), "Parsed time ({unwrapped}) does not match the expected time ({expected})");
+}
+
+#[rstest]
 fn parsed_moment_is_future() {
     // Arrange
     let input = "in 5 minutes";
@@ -26,7 +53,7 @@ fn parsed_moment_is_future() {
     assert_eq!(difference.num_minutes(), 5);
 }
 
-#[test]
+#[rstest]
 fn clean_input_cleans_in_syntax() {
     let input = "in 5 minutes";
 
@@ -35,7 +62,7 @@ fn clean_input_cleans_in_syntax() {
     assert_eq!(EXPECTED, result);
 }
 
-#[test]
+#[rstest]
 fn clean_input_cleans_from_syntax() {
     let input = "5 minutes from now";
 
@@ -44,7 +71,7 @@ fn clean_input_cleans_from_syntax() {
     assert_eq!(EXPECTED, result);
 }
 
-#[test]
+#[rstest]
 fn clean_input_cleans_combined_syntax() {
     let input = "in 5 minutes from now";
 

--- a/fercord_storage/CHANGELOG.md
+++ b/fercord_storage/CHANGELOG.md
@@ -3,8 +3,9 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
-## Changed
-- prelude now includes a lot more types
+
+- feat: prelude now includes a lot more types
+- chore: dependency updates
 
 ## [0.3.5] - 2024-12-02
 - chore: Update dependencies

--- a/fercord_storage/CHANGELOG.md
+++ b/fercord_storage/CHANGELOG.md
@@ -3,6 +3,8 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+## Changed
+- prelude now includes a lot more types
 
 ## [0.3.5] - 2024-12-02
 - chore: Update dependencies

--- a/fercord_storage/src/lib.rs
+++ b/fercord_storage/src/lib.rs
@@ -15,7 +15,7 @@ pub mod db;
 pub mod prelude {
     pub use sqlx_oldapi::any::AnyPool;
 
-    pub use crate::db;
+    pub use crate::db::{self, *};
     pub use crate::kv::{Identifiable, KVClient, KVIdentity};
-    pub use crate::model;
+    pub use crate::model::{self, *};
 }

--- a/fercord_storage/src/model/mod.rs
+++ b/fercord_storage/src/model/mod.rs
@@ -5,3 +5,6 @@ pub mod reminder;
 
 /// Store guild timezones as setting data
 pub mod guild_timezone;
+
+pub use reminder::*;
+pub use guild_timezone::*;


### PR DESCRIPTION
## Fercord bot
- feat: `/reminder` not also accepts `[day|tomorrow] at [hour][am|pm]` inputs.
- feat: `/roll` command to roll dice (up to 255d255)
- feat: `@bot register` prefix-command to register slash commands

## fercord_storage
- feat: expand prelude to select a lot more types